### PR TITLE
changes for torchscript compatibility

### DIFF
--- a/openpifpaf/export_libtorch.py
+++ b/openpifpaf/export_libtorch.py
@@ -1,0 +1,221 @@
+"""Export a checkpoint as an ONNX model.
+
+Applies onnx utilities to improve the exported model and
+also tries to simplify the model with onnx-simplifier.
+
+https://github.com/onnx/onnx/blob/master/docs/PythonAPIOverview.md
+https://github.com/daquexian/onnx-simplifier
+"""
+
+import argparse
+import shutil
+
+import torch
+
+import openpifpaf
+
+try:
+    import onnx
+    import onnx.utils
+except ImportError:
+    onnx = None
+
+try:
+    import onnxsim
+except ImportError:
+    onnxsim = None
+
+
+# monkey patch
+class MonkeyPatches:
+    def __init__(self):
+        self.original_compositehead_patched_forward = \
+            openpifpaf.network.heads.CompositeField.forward
+
+    def apply(self):
+        openpifpaf.network.heads.CompositeField.forward = \
+            self.compositehead_patched_forward
+
+    def revert(self):
+        openpifpaf.network.heads.CompositeField.forward = \
+            self.original_compositehead_patched_forward
+
+    @staticmethod
+    def compositehead_patched_forward(self_, x):
+        x = self_.dropout(x)
+
+        # classification
+        classes_x = [class_conv(x) for class_conv in self_.class_convs]
+        if not self_.training:
+            classes_x = [torch.sigmoid(class_x) for class_x in classes_x]
+
+        # regressions
+        regs_x = [reg_conv(x) * self_.dilation for reg_conv in self_.reg_convs]
+        regs_x_spread = [reg_spread(x) for reg_spread in self_.reg_spreads]
+        # regs_x_spread = [torch.nn.functional.leaky_relu(x + 3.0) - 3.0 for x in regs_x_spread]
+        # problem for ONNX is the "- 3.0"
+        regs_x_spread = [torch.clamp(x, min=-3.0) for x in regs_x_spread]
+
+        # scale
+        scales_x = [scale_conv(x) for scale_conv in self_.scale_convs]
+        scales_x = [torch.nn.functional.relu(scale_x) for scale_x in scales_x]
+
+        for _ in range(self_._quad):  # pylint: disable=protected-access
+            classes_x = [self_.dequad_op(class_x)[:, :, :-1, :-1]
+                         for class_x in classes_x]
+            regs_x = [self_.dequad_op(reg_x)[:, :, :-1, :-1]
+                      for reg_x in regs_x]
+            regs_x_spread = [self_.dequad_op(reg_x_spread)[:, :, :-1, :-1]
+                             for reg_x_spread in regs_x_spread]
+            scales_x = [self_.dequad_op(scale_x)[:, :, :-1, :-1]
+                        for scale_x in scales_x]
+
+        # reshape regressions:
+        # Accessing the shape of .data instead of the shape of reg_x saves
+        # nodes in the ONNX graph.
+        regs_x = [
+            reg_x.reshape(reg_x.data.shape[0],
+                          reg_x.data.shape[1] // 2,
+                          2,
+                          reg_x.data.shape[2],
+                          reg_x.data.shape[3])
+            for reg_x in regs_x
+        ]
+
+        return classes_x + regs_x + regs_x_spread + scales_x
+
+
+class GetPif(torch.nn.Module):
+    def forward(self, heads):  # pylint: disable=arguments-differ
+        return heads[0]
+
+
+class GetPifC(torch.nn.Module):
+    def forward(self, heads):  # pylint: disable=arguments-differ
+        return heads[0][0]
+
+
+def apply(checkpoint, outfile, verbose=True):
+    # monkey_patches = MonkeyPatches()
+    # monkey_patches.apply()
+
+    # dummy_input = torch.randn(1, 3, 193, 257)
+    dummy_input = torch.randn(1, 3, 97, 129)
+    # model, _ = openpifpaf.network.nets.factory(checkpoint=checkpoint)
+    model = openpifpaf.network.nets.factory_from_scratch(
+        "resnet50", headnames=("pif", "paf"), pretrained=False
+    )
+    torch.save(model, "model.pt")
+    # model = torch.nn.Sequential(model, GetPifC())
+
+    # Providing input and output names sets the display names for values
+    # within the model's graph. Setting these does not change the semantics
+    # of the graph; it is only for readability.
+    #
+    # The inputs to the network consist of the flat list of inputs (i.e.
+    # the values you would pass to the forward() method) followed by the
+    # flat list of parameters. You can partially specify names, i.e. provide
+    # a list here shorter than the number of inputs to the model, and we will
+    # only set that subset of names, starting from the beginning.
+    input_names = ['input_batch']
+    output_names = [
+        'pif_c',
+        'pif_r',
+        'pif_b',
+        'pif_s',
+        'paf_c',
+        'paf_r1',
+        'paf_r2',
+        'paf_b1',
+        'paf_b2',
+    ]
+
+    # torch.onnx.export(
+    #     model, dummy_input, outfile, verbose=verbose,
+    #     input_names=input_names, output_names=output_names,
+    #     # opset_version=10,
+    #     # do_constant_folding=True,
+    #     # dynamic_axes={  # TODO: gives warnings
+    #     #     'input_batch': {0: 'batch', 2: 'height', 3: 'width'},
+    #     #     'pif_c': {0: 'batch', 2: 'fheight', 3: 'fwidth'},
+    #     #     'pif_r': {0: 'batch', 3: 'fheight', 4: 'fwidth'},
+    #     #     'pif_b': {0: 'batch', 2: 'fheight', 3: 'fwidth'},
+    #     #     'pif_s': {0: 'batch', 2: 'fheight', 3: 'fwidth'},
+
+    #     #     'paf_c': {0: 'batch', 2: 'fheight', 3: 'fwidth'},
+    #     #     'paf_r1': {0: 'batch', 3: 'fheight', 4: 'fwidth'},
+    #     #     'paf_b1': {0: 'batch', 2: 'fheight', 3: 'fwidth'},
+    #     #     'paf_r2': {0: 'batch', 3: 'fheight', 4: 'fwidth'},
+    #     #     'paf_b2': {0: 'batch', 2: 'fheight', 3: 'fwidth'},
+    #     # },
+    # )
+    scripted = torch.jit.script(model)
+    torch.jit.save(scripted, "scripted.pt")
+
+    # monkey_patches.revert()
+
+
+def optimize(infile, outfile=None):
+    if outfile is None:
+        assert infile.endswith('.onnx')
+        outfile = infile
+        infile = infile.replace('.onnx', '.unoptimized.onnx')
+        shutil.copyfile(outfile, infile)
+
+    model = onnx.load(infile)
+    optimized_model = onnx.optimizer.optimize(model)
+    onnx.save(optimized_model, outfile)
+
+
+def check(modelfile):
+    model = onnx.load(modelfile)
+    onnx.checker.check_model(model)
+
+
+def polish(infile, outfile=None):
+    if outfile is None:
+        assert infile.endswith('.onnx')
+        outfile = infile
+        infile = infile.replace('.onnx', '.unpolished.onnx')
+        shutil.copyfile(outfile, infile)
+
+    model = onnx.load(infile)
+    polished_model = onnx.utils.polish_model(model)
+    onnx.save(polished_model, outfile)
+
+
+def simplify(infile, outfile=None):
+    if outfile is None:
+        assert infile.endswith('.onnx')
+        outfile = infile
+        infile = infile.replace('.onnx', '.unsimplified.onnx')
+        shutil.copyfile(outfile, infile)
+
+    simplified_model = onnxsim.simplify(infile, check_n=0, perform_optimization=False)
+    onnx.save(simplified_model, outfile)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--checkpoint', default='resnet50')
+    parser.add_argument('--outfile', default='openpifpaf-resnet50.onnx')
+    parser.add_argument('--simplify', dest='simplify', default=False, action='store_true')
+    parser.add_argument('--no-polish', dest='polish', default=True, action='store_false',
+                        help='runs checker, optimizer and shape inference')
+    parser.add_argument('--optimize', dest='optimize', default=False, action='store_true')
+    parser.add_argument('--no-check', dest='check', default=True, action='store_false')
+    args = parser.parse_args()
+
+    apply(args.checkpoint, args.outfile)
+    if args.simplify:
+        simplify(args.outfile)
+    if args.optimize:
+        optimize(args.outfile)
+    if args.polish:
+        polish(args.outfile)
+    if args.check:
+        check(args.outfile)
+
+
+if __name__ == '__main__':
+    main()

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -19,8 +19,8 @@ class BaseNetwork(torch.nn.Module):
         LOG.info('stride = %d', self.input_output_scale)
         LOG.info('output features = %d', self.out_features)
 
-    def forward(self, *args):
-        return self.net(*args)
+    def forward(self, inputs):
+        return self.net(inputs)
 
 
 class ShuffleNetV2Factory(object):

--- a/openpifpaf/network/resnet.py
+++ b/openpifpaf/network/resnet.py
@@ -1,0 +1,349 @@
+import torch
+import torch.nn as nn
+
+try:
+    from torch.hub import load_state_dict_from_url
+except ImportError:
+    from torch.utils.model_zoo import load_url as load_state_dict_from_url
+
+
+__all__ = ['ResNet', 'resnet18', 'resnet34', 'resnet50', 'resnet101',
+           'resnet152', 'resnext50_32x4d', 'resnext101_32x8d',
+           'wide_resnet50_2', 'wide_resnet101_2']
+
+
+model_urls = {
+    'resnet18': 'https://download.pytorch.org/models/resnet18-5c106cde.pth',
+    'resnet34': 'https://download.pytorch.org/models/resnet34-333f7ec4.pth',
+    'resnet50': 'https://download.pytorch.org/models/resnet50-19c8e357.pth',
+    'resnet101': 'https://download.pytorch.org/models/resnet101-5d3b4d8f.pth',
+    'resnet152': 'https://download.pytorch.org/models/resnet152-b121ed2d.pth',
+    'resnext50_32x4d': 'https://download.pytorch.org/models/resnext50_32x4d-7cdf4587.pth',
+    'resnext101_32x8d': 'https://download.pytorch.org/models/resnext101_32x8d-8ba56ff5.pth',
+    'wide_resnet50_2': 'https://download.pytorch.org/models/wide_resnet50_2-95faca4d.pth',
+    'wide_resnet101_2': 'https://download.pytorch.org/models/wide_resnet101_2-32ee1156.pth',
+}
+
+
+def conv3x3(in_planes, out_planes, stride=1, groups=1, dilation=1):
+    """3x3 convolution with padding"""
+    return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride,
+                     padding=dilation, groups=groups, bias=False, dilation=dilation)
+
+
+def conv1x1(in_planes, out_planes, stride=1):
+    """1x1 convolution"""
+    return nn.Conv2d(in_planes, out_planes, kernel_size=1, stride=stride, bias=False)
+
+
+class BasicBlock(nn.Module):
+    expansion = 1
+    __constants__ = ["downsample"]
+
+    def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
+                 base_width=64, dilation=1, norm_layer=None):
+        super(BasicBlock, self).__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        if groups != 1 or base_width != 64:
+            raise ValueError('BasicBlock only supports groups=1 and base_width=64')
+        if dilation > 1:
+            raise NotImplementedError("Dilation > 1 not supported in BasicBlock")
+        # Both self.conv1 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv3x3(inplanes, planes, stride)
+        self.bn1 = norm_layer(planes)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = conv3x3(planes, planes)
+        self.bn2 = norm_layer(planes)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x):
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        out += identity
+        out = self.relu(out)
+
+        return out
+
+
+class Bottleneck(nn.Module):
+    expansion = 4
+    __constants__ = ["downsample"]
+
+    def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
+                 base_width=64, dilation=1, norm_layer=None):
+        super(Bottleneck, self).__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        width = int(planes * (base_width / 64.)) * groups
+        # Both self.conv2 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv1x1(inplanes, width)
+        self.bn1 = norm_layer(width)
+        self.conv2 = conv3x3(width, width, stride, groups, dilation)
+        self.bn2 = norm_layer(width)
+        self.conv3 = conv1x1(width, planes * self.expansion)
+        self.bn3 = norm_layer(planes * self.expansion)
+        self.relu = nn.ReLU(inplace=True)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x):
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = self.relu(out)
+
+        out = self.conv3(out)
+        out = self.bn3(out)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        out += identity
+        out = self.relu(out)
+
+        return out
+
+
+class ResNet(nn.Module):
+
+    def __init__(self, block, layers, num_classes=1000, zero_init_residual=False,
+                 groups=1, width_per_group=64, replace_stride_with_dilation=None,
+                 norm_layer=None):
+        super(ResNet, self).__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        self._norm_layer = norm_layer
+
+        self.inplanes = 64
+        self.dilation = 1
+        if replace_stride_with_dilation is None:
+            # each element in the tuple indicates if we should replace
+            # the 2x2 stride with a dilated convolution instead
+            replace_stride_with_dilation = [False, False, False]
+        if len(replace_stride_with_dilation) != 3:
+            raise ValueError("replace_stride_with_dilation should be None "
+                             "or a 3-element tuple, got {}".format(replace_stride_with_dilation))
+        self.groups = groups
+        self.base_width = width_per_group
+        self.conv1 = nn.Conv2d(3, self.inplanes, kernel_size=7, stride=2, padding=3,
+                               bias=False)
+        self.bn1 = norm_layer(self.inplanes)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+        self.layer1 = self._make_layer(block, 64, layers[0])
+        self.layer2 = self._make_layer(block, 128, layers[1], stride=2,
+                                       dilate=replace_stride_with_dilation[0])
+        self.layer3 = self._make_layer(block, 256, layers[2], stride=2,
+                                       dilate=replace_stride_with_dilation[1])
+        self.layer4 = self._make_layer(block, 512, layers[3], stride=2,
+                                       dilate=replace_stride_with_dilation[2])
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(512 * block.expansion, num_classes)
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+
+        # Zero-initialize the last BN in each residual branch,
+        # so that the residual branch starts with zeros, and each residual block behaves like an identity.
+        # This improves the model by 0.2~0.3% according to https://arxiv.org/abs/1706.02677
+        if zero_init_residual:
+            for m in self.modules():
+                if isinstance(m, Bottleneck):
+                    nn.init.constant_(m.bn3.weight, 0)
+                elif isinstance(m, BasicBlock):
+                    nn.init.constant_(m.bn2.weight, 0)
+
+    def _make_layer(self, block, planes, blocks, stride=1, dilate=False):
+        norm_layer = self._norm_layer
+        downsample = None
+        previous_dilation = self.dilation
+        if dilate:
+            self.dilation *= stride
+            stride = 1
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                conv1x1(self.inplanes, planes * block.expansion, stride),
+                norm_layer(planes * block.expansion),
+            )
+
+        layers = []
+        layers.append(block(self.inplanes, planes, stride, downsample, self.groups,
+                            self.base_width, previous_dilation, norm_layer))
+        self.inplanes = planes * block.expansion
+        for _ in range(1, blocks):
+            layers.append(block(self.inplanes, planes, groups=self.groups,
+                                base_width=self.base_width, dilation=self.dilation,
+                                norm_layer=norm_layer))
+
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        x = self.maxpool(x)
+
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+
+        x = self.avgpool(x)
+        x = torch.flatten(x, 1)
+        x = self.fc(x)
+
+        return x
+
+
+def _resnet(arch, block, layers, pretrained, progress, **kwargs):
+    model = ResNet(block, layers, **kwargs)
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls[arch],
+                                              progress=progress)
+        model.load_state_dict(state_dict)
+    return model
+
+
+def resnet18(pretrained=False, progress=True, **kwargs):
+    r"""ResNet-18 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet18', BasicBlock, [2, 2, 2, 2], pretrained, progress,
+                   **kwargs)
+
+
+def resnet34(pretrained=False, progress=True, **kwargs):
+    r"""ResNet-34 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet34', BasicBlock, [3, 4, 6, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnet50(pretrained=False, progress=True, **kwargs):
+    r"""ResNet-50 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet50', Bottleneck, [3, 4, 6, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnet101(pretrained=False, progress=True, **kwargs):
+    r"""ResNet-101 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet101', Bottleneck, [3, 4, 23, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnet152(pretrained=False, progress=True, **kwargs):
+    r"""ResNet-152 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _resnet('resnet152', Bottleneck, [3, 8, 36, 3], pretrained, progress,
+                   **kwargs)
+
+
+def resnext50_32x4d(pretrained=False, progress=True, **kwargs):
+    r"""ResNeXt-50 32x4d model from
+    `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    kwargs['groups'] = 32
+    kwargs['width_per_group'] = 4
+    return _resnet('resnext50_32x4d', Bottleneck, [3, 4, 6, 3],
+                   pretrained, progress, **kwargs)
+
+
+def resnext101_32x8d(pretrained=False, progress=True, **kwargs):
+    r"""ResNeXt-101 32x8d model from
+    `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    kwargs['groups'] = 32
+    kwargs['width_per_group'] = 8
+    return _resnet('resnext101_32x8d', Bottleneck, [3, 4, 23, 3],
+                   pretrained, progress, **kwargs)
+
+
+def wide_resnet50_2(pretrained=False, progress=True, **kwargs):
+    r"""Wide ResNet-50-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_
+
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet('wide_resnet50_2', Bottleneck, [3, 4, 6, 3],
+                   pretrained, progress, **kwargs)
+
+
+def wide_resnet101_2(pretrained=False, progress=True, **kwargs):
+    r"""Wide ResNet-101-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_
+
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet('wide_resnet101_2', Bottleneck, [3, 4, 23, 3],
+                   pretrained, progress, **kwargs)

--- a/openpifpaf/predict.py
+++ b/openpifpaf/predict.py
@@ -98,7 +98,9 @@ def main():
     args = cli()
 
     # load model
-    model_cpu, _ = nets.factory_from_args(args)
+    #model_cpu, _ = nets.factory_from_args(args)
+    model_cpu = torch.jit.load(os.path.join("./", "scripted.pt"))
+    # model_cpu = torch.load(os.path.join("./", "model.pt"))
     model = model_cpu.to(args.device)
     if not args.disable_cuda and torch.cuda.device_count() > 1:
         LOG.info('Using multiple GPUs: %d', torch.cuda.device_count())


### PR DESCRIPTION
python -m openpifpaf.export_libtorch --checkpoint resnet50

python -m openpifpaf.predict --basenet resnet50 image-00436-bd661db0-14a2-477b-ae27-9b6049bb9ff1.png

python -m openpifpaf.predict --checkpoint resnet50 image-00436-bd661db0-14a2-477b-ae27-9b6049bb9ff1.png

python -m openpifpaf.export_onnx --checkpoint resnet50


img = PIL.Image.open(os.path.join(root_dir, "image-00436-bd661db0-14a2-477b-ae27-9b6049bb9ff1.png"))
skeleton = PIL.Image.open(os.path.join(root_dir, "image-00436-bd661db0-14a2-477b-ae27-9b6049bb9ff1.png.skeleton.png"))

```
import onnx

onnx_model_path = os.path.join(root_dir, "openpifpaf-resnet50.onnx")
model = onnx.load(onnx_model_path)
onnx.checker.check_model(model)

import pprint

pp = pprint.PrettyPrinter(indent=2)

#pp.pprint(onnx.helper.printable_graph(model.graph))

scripted_model = torch.jit.load(os.path.join(root_dir, "scripted.pt"))
scripted_model
```